### PR TITLE
REDCap restructured, so this code adjusts to deal with it in a less brittle fashion

### DIFF
--- a/TwoColumnChecksExternalModule.php
+++ b/TwoColumnChecksExternalModule.php
@@ -26,24 +26,26 @@ class TwoColumnChecksExternalModule extends AbstractExternalModule
 <script>
         function twoColumnCheckboxes() {
             const checkboxes = {};
-            $('tr td div.choicevert').each(function(index, ob) {
-        	    const row = $(ob).closest('tr').attr('id');
-        	    if (typeof checkboxes[row] == 'undefined') {
-        		    checkboxes[row] = 0;
-        	    }
-        	    checkboxes[row]++;
+	        $('tr td').each(function(index, ob) {
+                if ($(ob).find('div.choicevert').length > 0) {
+        	        const row = $(ob).closest('tr').attr('id');
+        	        if (typeof checkboxes[row] == 'undefined') {
+        		        checkboxes[row] = 0;
+        	        }
+        	        checkboxes[row]++;
+                }
             });
             for (let row in checkboxes) {
         	    let done = false;
         	    if (checkboxes[row] > 10) {
                     const checksInCol = Math.ceil(checkboxes[row] / 2);
-                    $('#'+row+' td div.choicevert').each(function(index, ob) {
+                    $('#'+row+' td').find('div.choicevert').each(function(index, ob) {
                         if (!done) {
                             $line
                         }
                         done = true;
                     });
-                    $('#'+row+' td div.choicevert').each(function(index, ob) {
+                    $('#'+row+' td').find('div.choicevert').each(function(index, ob) {
                         if (index < checksInCol) {
                             $(ob).appendTo('#'+row+'-left');
                         } else {


### PR DESCRIPTION
This is the full External Module version of the code reviewed in this PR. The code change is essentially the same. I maintained it in two places because it's easy to forget to turn on two-column checks on the projects with a VUNet lookup. But Rebecca needs them both in the same project, so this is the easiest way to remember. If you can think of a better way that reminds us without incurring DRY, let me know.

Rob added a `<div>` item in the HTML, so I moved the jQuery selectors to use .find() instead.