### PR TITLE
Updates based on security scan

### DIFF
--- a/TwoColumnChecksExternalModule.php
+++ b/TwoColumnChecksExternalModule.php
@@ -9,13 +9,6 @@ require_once APP_PATH_DOCROOT.'Classes/Files.php';
 
 class TwoColumnChecksExternalModule extends AbstractExternalModule
 {
-        private $email_requested = false;
-
-        public function __construct(){
-                parent::__construct();
-                $this->disableUserBasedSettingPermissions();
-        }
-
         function hook_survey_page ($project_id, $record,$instrument,$event_id, $group_id, $survey_hash,$response_id, $repeat_instance) {
             if (version_compare(REDCAP_VERSION, '12.0.0', '<')) {
                 $line = "$(ob).parent().find('label.fl').after(\"<div id='\"+row+\"-left' class='leftCol'></div><div id='\"+row+\"-right' class='rightCol'></div>\");";


### PR DESCRIPTION
Sorry for the repeat: I didn't run REDCap's scanner on this module until after merging. I learned two things:
- ExtMods doesn't like constructors.
- disableUserBasedSettingPermissions() has been deprecated.